### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kwrite.json
+++ b/org.kde.kwrite.json
@@ -18,7 +18,7 @@
         "/bin/kate",
         "/lib/pkgconfig",
         "/lib/plugins",
-        "/share/doc/HTML/*/kate",
+        "/share/doc",
         "/share/kateproject",
         "/share/man",
         "/share/plasma"


### PR DESCRIPTION
The installed size reduced from 13.1 MB to 5.4 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.